### PR TITLE
V4 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,18 +4,18 @@
   "version": "1.0.0",
   "author": "Hunter Chang",
   "dependencies": {
-    "gatsby": "^2.19.32",
-    "gatsby-plugin-manifest": "^2.2.44",
-    "gatsby-plugin-offline": "^3.0.37",
-    "gatsby-plugin-react-helmet": "^3.1.23",
-    "gatsby-plugin-sass": "^2.1.30",
-    "node-sass": "^4.13.1",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
-    "react-helmet": "^5.2.1",
+    "gatsby": "^4.24.5",
+    "gatsby-plugin-manifest": "^4.24.0",
+    "gatsby-plugin-offline": "^5.24.0",
+    "gatsby-plugin-react-helmet": "^5.24.0",
+    "gatsby-plugin-sass": "^5.24.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-helmet": "^6.1.0",
     "react-scroll-to-element": "^0.2.0",
-    "react-scrollspy": "^3.4.2",
-    "react-waypoint": "^9.0.2"
+    "react-scrollspy": "^3.4.3",
+    "react-waypoint": "^10.3.0",
+    "sass": "^1.55.0"
   },
   "keywords": [
     "gatsby"

--- a/src/assets/scss/base/_typography.scss
+++ b/src/assets/scss/base/_typography.scss
@@ -127,7 +127,7 @@
 		border-left: solid 4px;
 		font-style: italic;
 		margin: 0 0 _size(element-margin) 0;
-		padding: (_size(element-margin) / 4) 0 (_size(element-margin) / 4) _size(element-margin);
+		padding: calc(_size(element-margin) / 4) 0 calc(_size(element-margin) / 4) _size(element-margin);
 	}
 
 	code {

--- a/src/assets/scss/libs/_skel.scss
+++ b/src/assets/scss/libs/_skel.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: ();
 
 	/// Vendor prefixes.
 	/// @var {list}
@@ -573,7 +573,7 @@
 			}
 
 		// Expand just the value?
-			@elseif $expandValue {
+			@else if $expandValue {
 			    @each $vendor in $vendor-prefixes {
 			        #{$property}: #{str-replace-all($value, '-prefix-', $vendor)};
 			    }


### PR DESCRIPTION
Upgraded all components + supports to work with Gatsby v4.
Migrated from node-sass to dart-sass to work with current technology.

It still doesn't like the one calc function but it builds fine.

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(100%, 3) or calc(100% / 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
19 │             width: calc(#{(100% / 3)} - #{_size(element-margin)});
   │                            ^^^^^^^^
   ╵
    src/assets/scss/components/_features.scss 19:19  @import
    src/assets/scss/main.scss 61:10                  root stylesheet
```
which comes out on the front end okay as
```
.features li {
    width: calc(33.3333% - 2em);
    margin-left: 2em;
    margin-top: 3em;
    padding: 0px;
}
```

If you like this pull request, can you add the hacktoberfest-accepted label?

![Screen Shot 2022-10-31 at 11 26 28 AM](https://user-images.githubusercontent.com/38568655/199082261-f68d95df-6d1e-4bdf-9f53-c36022c9a884.png)
